### PR TITLE
Better pretty-printing

### DIFF
--- a/resources/public/css/tryclojure.css
+++ b/resources/public/css/tryclojure.css
@@ -48,43 +48,47 @@ body {
  border: 1px solid #aaa;
 }
 
-#console div.jquery-console-inner { 
+#console .jquery-console-inner div {
+  white-space: pre;
+}
+
+#console div.jquery-console-inner {
  width:580px;
- height:200px; 
+ height:200px;
  margin: 10px 10px;
- overflow:auto; 
+ overflow:auto;
  text-align:left;
 }
 #console div.jquery-console-message-value {
-  color:#0066FF; 
+  color:#0066FF;
   font-family:monospace;
-  padding:0.1em; 
+  padding:0.1em;
 }
 #console div.jquery-console-prompt-box {
- color:#444; font-family:monospace; 
+ color:#444; font-family:monospace;
 }
 #console div.jquery-console-focus span.jquery-console-cursor {
  background:#333; color:#eee; font-weight:bold;
 }
 #console div.jquery-console-message-error {
  color:#ef0505; font-family:sans-serif; font-weight:bold;
- padding:0.1em; 
+ padding:0.1em;
 }
 #console div.jquery-console-message-success {
  color:#187718; font-family:monospace;
- padding:0.1em; 
+ padding:0.1em;
 }
-#console span.jquery-console-prompt-label { 
+#console span.jquery-console-prompt-label {
  font-weight:bold;
 }
 
-.bottom { 
- background-color: white; color: #333; 
+.bottom {
+ background-color: white; color: #333;
 }
-.bottom a,a:visited { 
- color: #111; 
+.bottom a,a:visited {
+ color: #111;
 }
-table.bottom { 
+table.bottom {
  width: 100%; border: 1px solid black;
 }
 
@@ -93,13 +97,13 @@ table.bottom {
  text-align: center;
  margin-top: 10px;
 }
-#buttons a { 
+#buttons a {
 /* color: #4881d8;*/
  color: #3D5B99;
  padding: .3em 1em;
  margin-right: .7em;
  font-family: Helvetica, sans-serif;
- font-size: 16px; 
+ font-size: 16px;
  font-weight: bold;
  background: #90b4fe;
  border-radius: 5px;
@@ -110,10 +114,10 @@ table.bottom {
 }
 #buttons a:hover {
  color: #5881d8;
- cursor: pointer; 
+ cursor: pointer;
 }
 
-#changer { 
+#changer {
  margin: 10px;
  padding: 0.25em 0.5em 0.25em 0.5em;
  background: #EAF2F5;
@@ -148,11 +152,11 @@ div#tuttext {
 div.continue {
  width: 100%;
  text-align: center;
- padding-top: 0.5em; 
+ padding-top: 0.5em;
 }
 
-div.footer { 
- text-align: center; 
+div.footer {
+ text-align: center;
 }
 
 /* Coderay alpha style */
@@ -204,7 +208,7 @@ table.code td { padding: 2px 4px; vertical-align: top; }
 
 /* operator */
 #changer .code span.cl {
- 
+
 }
 
 /* number */

--- a/src/tryclojure/views/eval.clj
+++ b/src/tryclojure/views/eval.clj
@@ -1,7 +1,8 @@
 (ns tryclojure.views.eval
   (:require [noir.core :refer [defpage]]
             [tryclojure.models.eval :refer [eval-request]]
-            [noir.response :as resp]))
+            [noir.response :as resp]
+            [clojure.pprint]))
 
 (defpage "/eval.json" {:keys [expr jsonp]}
   (let [{:keys [expr result error message] :as res} (eval-request expr)
@@ -9,8 +10,9 @@
                res
                (let [[out res] result]
                  {:expr (pr-str expr)
-                  :result (str out (pr-str res))}))]
-    
+                  :result (str out (with-out-str (clojure.pprint/pprint res)))
+                  }))]
+
     (if jsonp
       (resp/jsonp jsonp data)
       (resp/json data))))


### PR DESCRIPTION
This PR introduces `(with-out-str (clojure.pprint/pprint ...))` as a method of pretty-printing instead of pr-str. There is also a little CSS change. Here is a comparison: [before](https://f.cloud.github.com/assets/316910/523346/07880888-c0ae-11e2-9a69-0c1bf420ea23.png) and [after](https://f.cloud.github.com/assets/316910/523344/f5550300-c0ad-11e2-8d46-04c3e71b1aab.png).
