### PR TITLE
Fix #59 ignore all leiningen artifacts and swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 pom.xml
+pom.xml.asc
 *jar
-lib
-classes
 *~
+/lib/
+/classes/
+/target/
+/checkouts/
 .lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures
+.nrepl-port


### PR DESCRIPTION
Copy https://github.com/github/gitignore/blob/master/Leiningen.gitignore to make development a little cleaner. Still includes `*~` to ignore emacs swap files.
