### PR TITLE
Fix #61 preserve tutorial content height between transitions

### DIFF
--- a/resources/public/javascript/tryclojure.js
+++ b/resources/public/javascript/tryclojure.js
@@ -60,9 +60,9 @@ function goToPage(pageNumber) {
 	currentPage = pageNumber;
 
 	var block = $("#changer");
-  	block.fadeOut(function(e) {
+  	block.fadeTo("fast", 0, function(e) {
     	block.load("/tutorial", { 'page' : pages[pageNumber] }, function() {
-      block.fadeIn();
+      block.fadeTo("fast", 100);
       changerUpdated();
 		});
 	});


### PR DESCRIPTION
Use jquery [`fadeTo`](https://api.jquery.com/fadeTo/) instead of `fadeIn` and `fadeOut` to adjust opacity without changing content height.

This prevents the copyright notice jump up and down the page between tutorial steps.
