### PR TITLE
Issue #53 Updated to Clojure 1.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject tryclojure "0.1.0-SNAPSHOT"
   :description "A simple web-based Clojure REPL for trying out Clojure without having to install it."
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [lib-noir "0.8.1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [lib-noir "0.9.9"]
                  [compojure "1.1.6"]
                  [ring-server "0.3.1"]
                  [commons-lang/commons-lang "2.5"]

--- a/resources/public/javascript/tryclojure.js
+++ b/resources/public/javascript/tryclojure.js
@@ -61,8 +61,9 @@ function goToPage(pageNumber) {
 
 	var block = $("#changer");
   	block.fadeOut(function(e) {
-    	block.load("/tutorial", { 'page' : pages[pageNumber] }, function() {
-      block.fadeIn();
+    	$.get("/tutorial", { 'page' : pages[pageNumber] }, function(data) {
+			block.html(data)
+			block.fadeIn();
       changerUpdated();
 		});
 	});

--- a/src/tryclojure/server.clj
+++ b/src/tryclojure/server.clj
@@ -11,7 +11,7 @@
   [(GET "/" [] (home/root-html))
    (GET "/about" [] (home/about-html))
    (GET "/links" [] (home/links-html))
-   (POST "/tutorial" [:as {args :params}] (tutorial/tutorial-html (args :page)))
+   (GET "/tutorial" [:as {args :params}] (tutorial/tutorial-html (args :page)))
    (POST "/eval.json" [:as {args :params}] (eval/eval-json (args :expr) (args :jsonp)))
    (GET "/eval.json" [:as {args :params}] (eval/eval-json (args :expr) (args :jsonp)))
    (route/resources "/")


### PR DESCRIPTION
Close #53. Bump Clojure to the latest stable release, 1.7.0.

The only major switch was avoiding the [ring-clojure/ring-anti-forgery](https://github.com/ring-clojure/ring-anti-forgery) 403 permissions error that was being thrown when POST to `/tutorial`. The library is included in noir.util.middleware from [ring-clojure/ring-defaults](https://github.com/ring-clojure/ring-defaults). For more information about ring-anti-forgery and POST see https://github.com/ring-clojure/ring-anti-forgery/issues/2. For some reason, upgrading to 1.7 triggered this middleware on this endpoint only.

To remedy, updated `/tutorial` to a GET, forgoing the nice `$.load` convenience function and using `$.get`. This has the nicety of being more semantically correct anyways. `$.load` defaults to a GET when no data is given, as in the setupLink function.

Upgraded [lib-noir](https://github.com/noir-clojure/lib-noir) to 0.9.9. In versions up to 0.9.8, it fails to start, raising an exception due to an undeclared variable "pretty".
